### PR TITLE
Simplify Travis CI config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 git:
   depth: 1
 
@@ -10,16 +8,9 @@ branches:
 
 language: node_js
 
-# cache node modules
-cache:
-  directories:
-    - $HOME/.npm
-    - node_modules
+cache: npm
 
 node_js:
-  - "11"
+  - "12"
   - "10"
   - "8"
-
-before_install:
-  - npm install -g npm@latest


### PR DESCRIPTION
* use the `npm` cache alias
* remove the obsolete `sudo: false`
* add Node.js 12.x
* stop updating npm to the latest so that the test conditions match the supported Node.js versions
